### PR TITLE
Phase 1 - extract model api V2  (wip for Review) DO NOT MERGE

### DIFF
--- a/packages/accounts-base/accounts_common.js
+++ b/packages/accounts-base/accounts_common.js
@@ -7,7 +7,15 @@
  * - connection {Object} Optional DDP connection to reuse.
  * - ddpUrl {String} Optional URL for creating a new DDP connection.
  */
+
+  
+//import {AccountsProvider} from './accounts_provider';
+
 export class AccountsCommon {
+  // AccountsCommon no longer depend on a DDP connection or AccountsProvider
+  // Concrete Subclass AccountsClient will manage client side DDP connection
+  // Concrete Subclass AccountsServer will manage AccountsProvider instance(s)
+  
   constructor(options) {
     // Currently this is read directly by packages like accounts-password
     // and accounts-ui-unstyled.
@@ -16,14 +24,19 @@ export class AccountsCommon {
     // Note that setting this.connection = null causes this.users to be a
     // LocalCollection, which is not what we want.
     this.connection = undefined;
-    this._initConnection(options || {});
+//    this._initConnection(options || {});
 
     // There is an allow call in accounts_server.js that restricts writes to
     // this collection.
+
+/*
     this.users = new Mongo.Collection("users", {
       _preventAutopublish: true,
       connection: this.connection
     });
+*/
+
+//    this.users = new AccountsProvider(this.connection);
 
     // Callback exceptions are printed with Meteor._debug and ignored.
     this._onLoginHook = new Hook({
@@ -49,11 +62,12 @@ export class AccountsCommon {
    * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
    * @locus Anywhere but publish functions
    */
+  /*
   user() {
     var userId = this.userId();
-    return userId ? this.users.findOne(userId) : null;
+    return userId ? this.users.findSingle(userId) : null;
   }
-
+*/
   // Set up config for the accounts system. Call this on both the client
   // and the server.
   //
@@ -155,7 +169,7 @@ export class AccountsCommon {
   onLoginFailure(func) {
     return this._onLoginFailureHook.register(func);
   }
-
+/*
   _initConnection(options) {
     if (! Meteor.isClient) {
       return;
@@ -188,7 +202,7 @@ export class AccountsCommon {
       this.connection = Meteor.connection;
     }
   }
-
+*/
   _getTokenLifetimeMs() {
     return (this._options.loginExpirationInDays ||
             DEFAULT_LOGIN_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000;
@@ -217,6 +231,7 @@ var Ap = AccountsCommon.prototype;
 /**
  * @summary Get the current user id, or `null` if no user is logged in. A reactive data source.
  * @locus Anywhere but publish functions
+ * @importFromPackage meteor
  */
 Meteor.userId = function () {
   return Accounts.userId();
@@ -225,10 +240,12 @@ Meteor.userId = function () {
 /**
  * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
  * @locus Anywhere but publish functions
+ * @importFromPackage meteor
  */
 Meteor.user = function () {
   return Accounts.user();
 };
+
 
 // how long (in days) until a login token expires
 var DEFAULT_LOGIN_EXPIRATION_DAYS = 90;

--- a/packages/accounts-base/accounts_provider.js
+++ b/packages/accounts-base/accounts_provider.js
@@ -1,0 +1,499 @@
+/**
+ * Created by sing on 2/3/16.
+ *
+ * WORK IN PROGRESS
+ */
+
+
+
+export class AccountsProvider {
+    // this is an Abstract class that all Database Providers should implement
+    // currently, it is also the Mongo Provider
+    // TODO: extract into external TypeScript abstract class - linked via npm module(s)
+    constructor(conn, options) {
+        // Currently this is read directly by packages like accounts-password
+        // and accounts-ui-unstyled.
+        this._options = {};
+        this.connection = conn
+        this.users = new Mongo.Collection("users", {
+            _preventAutopublish: true,
+            connection: this.connection
+        });
+    }
+
+
+    insertUser(fullUser) {
+        console.log('called in insert with ' + JSON.stringify(fullUser));
+        var userId;
+
+        try {
+            userId = this.users.insert(fullUser);
+        } catch (e) {
+            // XXX string parsing sucks, maybe
+            // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
+            if (e.name !== 'MongoError') throw e;
+            if (e.code !== 11000) throw e;
+            if (e.err.indexOf('emails.address') !== -1)
+                throw new Meteor.Error(403, "Email already exists.");
+            if (e.err.indexOf('username') !== -1)
+                throw new Meteor.Error(403, "Username already exists.");
+            // XXX better error reporting for services.facebook.id duplicate, etc
+            throw e;
+        }
+        return userId;
+    }
+    expireTokens(oldestValidDate, userId) {
+
+        var userFilter = userId ? {_id: userId} : {};
+
+
+        // Backwards compatible with older versions of meteor that stored login token
+        // timestamps as numbers.
+        this.users.update(_.extend(userFilter, {
+            $or: [
+                {"services.resume.loginTokens.when": {$lt: oldestValidDate}},
+                {"services.resume.loginTokens.when": {$lt: +oldestValidDate}}
+            ]
+        }), {
+            $pull: {
+                "services.resume.loginTokens": {
+                    $or: [
+                        {when: {$lt: oldestValidDate}},
+                        {when: {$lt: +oldestValidDate}}
+                    ]
+                }
+            }
+        }, {multi: true});
+        // The observe on Meteor.users will take care of closing connections for
+        // expired tokens.
+    }
+
+
+   clearAllLoginTokens(userId) {
+       this.users.update(userId, {
+           $set: {
+               'services.resume.loginTokens': []
+           }
+       });
+   }
+
+   insertHashedLoginToken(userId, hashedToken, qry) {
+    // console.log("called insert login token " + userId + " --- " + JSON.stringify(hashedToken) + " query is " + JSON.stringify(qry));
+       var query = qry ? _.clone(qry) : {};
+       query._id = userId;
+       this.users.update(query, {
+           $addToSet: {
+               "services.resume.loginTokens": hashedToken
+           }
+       });
+
+   }
+    findById(userid) {
+
+        return this.users.findOne({_id: userid});
+    }
+
+   // user = Meteor.users.findOne({ _id: query.id });
+
+
+    findCurrentUser(userId) {
+
+        return this.users.find({
+            _id: userId
+        }, {
+            fields: {
+                profile: 1,
+                username: 1,
+                emails: 1
+            }
+        });
+    }
+
+    findUserWithNewtoken(hashedToken) {
+      return  this.users.findOne(
+            {"services.resume.loginTokens.hashedToken": hashedToken});
+    }
+
+
+    findUserWithNewOrOld(newToken, oldToken) {
+      return  this.users.findOne({
+            $or: [
+                {"services.resume.loginTokens.hashedToken": newToken},
+                {"services.resume.loginTokens.token": oldToken}
+            ]
+        });
+    }
+    deleteSavedTokens(userId, tokensToDelete) {
+
+        if (tokensToDelete) {
+            this.users.update(userId, {
+                $unset: {
+                    "services.resume.haveLoginTokensToDelete": 1,
+                    "services.resume.loginTokensToDelete": 1
+                },
+                $pullAll: {
+                    "services.resume.loginTokens": tokensToDelete
+                }
+            });
+        }
+    }
+    deleteSavedTokensforAllUsers() {
+        this.users.find({
+            "services.resume.haveLoginTokensToDelete": true
+        }, {
+            "services.resume.loginTokensToDelete": 1
+        }).forEach(function (user) {
+            this.deleteSavedTokens(
+                user._id,
+                user.services.resume.loginTokensToDelete
+            );
+        });
+    }
+
+    // eliminated accounts dependency
+    removeOtherTokens(userId, curToken) {
+        if (!userId) {
+            throw new Meteor.Error("You are not logged in.");
+        }
+       // var currentToken = accounts._getLoginToken(connection.id);
+        this.users.update(userId, {
+            $pull: {
+                "services.resume.loginTokens": {hashedToken: {$ne: curToken}}
+            }
+        });
+    }
+
+    // eliminated accounts dependency
+    getNewToken(userId, curToken, newToken) {
+        var user = this.users.findOne(userId, {
+            fields: { "services.resume.loginTokens": 1 }
+        });
+        if (! userId || ! user) {
+            throw new Meteor.Error("You are not logged in.");
+        }
+        // Be careful not to generate a new token that has a later
+        // expiration than the curren token. Otherwise, a bad guy with a
+        // stolen token could use this method to stop his stolen token from
+        // ever expiring.
+       //  var currentHashedToken = accounts._getLoginToken(connection.id);
+        var currentStampedToken = _.find(
+            user.services.resume.loginTokens,
+            function (stampedToken) {
+                return stampedToken.hashedToken === curToken;
+            }
+        );
+        if (! currentStampedToken) { // safety belt: this should never happen
+            throw new Meteor.Error("Invalid login token");
+        }
+        //var newStampedToken = accounts._generateStampedLoginToken();
+
+
+        newToken.when = currentStampedToken.when;
+
+        return newToken;
+
+    }
+  addNewHashedTokenIfOldUnhashedStillExists(userId, oldToken, newHashedToken, when) {
+    //  console.log("called addNewHasedTokenIfOldUnhashedStillExists with userID " + userId + "oldToken= " + oldToken + "newToken =" + newHashedToken +  "when = " + when);
+    this.users.update({_id: userId,
+            "services.resume.loginTokens.token": oldToken},
+    {
+    $addToSet: {
+        "services.resume.loginTokens":
+        {
+            "hashedToken":  newHashedToken,
+                "when":when
+        }
+    }});
+  }
+
+
+   removeOldTokenAfterAddingNew(userid, oldToken) {
+       // console.log("called removeOldTokenAfterAddingNew with userID " + userid + "oldToken= " + oldToken);
+
+       this.users.update(userid, {
+           $pull: {
+               "services.resume.loginTokens": {"token": oldToken}
+           }
+       });
+   }
+
+    destroyToken(userId, loginToken) {
+
+        this.users.update(userId, {
+            $pull: {
+                "services.resume.loginTokens": {
+                    $or: [
+                        {hashedToken: loginToken},
+                        {token: loginToken}
+                    ]
+                }
+            }
+        });
+
+    }
+
+    findSingleLoggedIn(userId) {
+       return this.users.findOne(userId, {
+            fields: {
+                "services.resume.loginTokens": true
+            }
+        });
+    }
+
+    saveTokenAndDeleteLater(userId, tokens, hashedStampedToken) {
+        this.users.update(userId, {
+            $set: {
+                "services.resume.loginTokensToDelete": tokens,
+                "services.resume.haveLoginTokensToDelete": true
+            },
+            $push: {"services.resume.loginTokens": hashedStampedToken}
+        });
+
+    }
+
+    // password_server requirements
+
+   findByResetToken(token) {
+     return this.users.findOne({"services.password.reset.token": token});
+
+   }
+
+   findByVerificationTokens(token) {
+       return this.users.findOne({"services.email.verificationTokens.token": token});
+   }
+    updateToBcrypt(userid, salted) {
+     this.users.update(userid, {$unset: { 'services.password.srp': 1 }, $set: { 'services.password.bcrypt': salted }});
+    }
+
+    setUsername(userid, username) {
+        this.users.update({_id: userid}, {$set: {username: username}});
+    }
+
+    replaceAllTokensOtherThanCurrentConnection(userId, hashed, currentToken) {
+        this.users.update({ _id: userId },
+        {
+            $set: { 'services.password.bcrypt': hashed },
+            $pull: {
+                'services.resume.loginTokens': { hashedToken: { $ne: currentToken } }
+                    },
+            $unset: { 'services.password.reset': 1 }
+        }
+        );
+    }
+
+    changePasswordResetVerifyEmail(userid, email, token, hashed) {
+       return this.users.update(
+        {
+            _id: userid,
+            'emails.address': email,
+            'services.password.reset.token': token
+        },
+        {$set: {'services.password.bcrypt': hashed,
+            'emails.$.verified': true},
+            $unset: {'services.password.reset': 1,
+                'services.password.srp': 1}});
+    }
+
+    setVerificationTokens(userId, tokenRecord) {
+        this.users.update(
+            {_id: userId},
+            {$push: {'services.email.verificationTokens': tokenRecord}});
+    }
+
+    setResetToken(userId, tokenRecord) {
+        this.users.update(userId, {
+            $set: {
+                "services.password.reset": tokenRecord
+            }
+        });
+    }
+
+    setEmailVerified(userid, addr) {
+        this.users.update({_id: userid, 'emails.address': addr},
+            {
+                $set: {'emails.$.verified': true},
+                $pull: {'services.email.verificationTokens': {address: addr}}
+            });
+    }
+
+    addEmailVerified(userId, email, verified) {
+        this.users.update(
+            {_id: userId},
+            {$push: {emails: {address: email, verified: verified}}});
+    }
+
+    setNewEmailVerified(userid, email, newEmail, verified) {
+        this.users.update({_id: userid, 'emails.address': email},
+            {
+                $set: {
+                    'emails.$.address': newEmail,
+                    'emails.$.verified': verified
+                }
+            });
+    }
+
+
+    addEmailAddressVerified(userid, newEmail, verified) {
+        this.users.update({_id: userid},
+            {
+                $addToSet: {
+                    emails: {
+                        address: newEmail,
+                        verified: verified
+                    }
+                }
+            });
+    }
+    forceChangePassword(userid, hashedPassword, loggedout) {
+        var update = {
+            $unset: {
+                'services.password.srp': 1, // XXX COMPAT WITH 0.8.1.3
+                'services.password.reset': 1
+            },
+            $set: {'services.password.bcrypt': hashedPassword }
+        };
+
+        if (loggedout) {
+            update.$unset['services.resume.loginTokens'] = 1;
+        }
+
+        this.users.update({_id: userid}, update);
+    }
+
+    undoEmailAddressUpdate(userid, newEmail) {
+        this.users.update({_id: userid}, {$pull: {emails: {address: newEmail}}});
+    }
+
+    setSRP(userId, identity, salt, verifier) {
+        this.users.update(
+            userId,
+            {
+                '$set': {
+                    'services.password.srp': {
+                        "identity": identity,
+                        "salt": salt,
+                        "verifier": verifier
+                    }
+                }
+            });
+    }
+
+    //  The following are mostly used in setup of package tests  - via TinyTest
+    findByUsername(username) {
+     return this.users.findOne({username: username});
+    }
+    removeByUsername(username) {
+     return this.users.remove({username: username});
+    }
+
+    unsetProfile(userId) {
+        this.users.update(userId,
+        {$unset: {profile: 1, username: 1}});
+    }
+
+    findById(userId) {
+       return this.users.findOne(userId);
+    }
+    findByService(selector) {
+      return this.users.findOne(selector);
+    }
+    // this needs to be tighten up
+    findOneBySelector(selector) {
+        return this.users.findOne(selector);
+    }
+    findBySelector(selector) {
+        return this.users.find(selector);
+    }
+    updateAttributes(userid,attrs ) {
+        this.users.update(userid, {
+            $set: attrs
+        });
+    }
+
+    setResumeTokens(userId, tokens) {
+        this.users.update(userId,
+            {  $set: {"services.resume.loginTokens": tokens }});
+    }
+
+
+    removeById(userId) {
+        this.users.remove(userId);
+    }
+
+    insertLoginToken(userId, stampedToken) {
+        // console.log("INSERT normal login token - userid is " + userId + " token is " + JSON.stringify(stampedToken));
+        this.users.update(
+            userId,
+            {$push: {'services.resume.loginTokens': stampedToken}}
+        );
+    }
+
+    findUsersByService(servicehash) {
+        return this.users.find(servicehash).fetch();
+    }
+    findUsersInServices(serviceIdsArray) {
+        return this.users.find({"services.weibo.id": {$in: serviceIdsArray}});
+    }
+    getMongoUsersForReactiveWork() {
+        // only hook available to support reactivity when backed by mongo
+        // alternative data providers will return null
+        return this.users;
+    }
+
+    // and methods required in account-password package tests
+    updateEmail(userId, newEmail) {
+        this.users.update(userId, {$set: {"emails.0.address": newEmail}});
+    }
+    updateDisallowedAndProfile(userId, disallowed, profile , func) {
+        this.users.update(userId, {$set: {disallowed: disallowed, 'profile.updated': profile}}, func);
+    }
+
+    updateProfile(userId, profile, func ) {
+        this.users.update(userId, {$set: {'profile.updated': profile}}, func);
+    }
+    updateProfileByUsername(uname, profile) {
+        this.users.update({username: uname}, {$set: {'profile.updated': profile}});
+    }
+
+    setupUsersCollection() {
+        this.users.allow({
+            // clients can modify the profile field of their own document, and
+            // nothing else.
+            update: function (userId, user, fields, modifier) {
+                // make sure it is our record
+                if (user._id !== userId)
+                    return false;
+
+                // user can only modify the 'profile' field. sets to multiple
+                // sub-keys (eg profile.foo and profile.bar) are merged into entry
+                // in the fields list.
+                if (fields.length !== 1 || fields[0] !== 'profile')
+                    return false;
+
+                return true;
+            },
+            fetch: ['_id'] // we only look at _id.
+        });
+
+        /// DEFAULT INDEXES ON USERS
+        this.users._ensureIndex('username', {unique: 1, sparse: 1});
+        this.users._ensureIndex('emails.address', {unique: 1, sparse: 1});
+        this.users._ensureIndex('services.resume.loginTokens.hashedToken',
+            {unique: 1, sparse: 1});
+        this.users._ensureIndex('services.resume.loginTokens.token',
+            {unique: 1, sparse: 1});
+        // For taking care of logoutOtherClients calls that crashed before the
+        // tokens were deleted.
+        this.users._ensureIndex('services.resume.haveLoginTokensToDelete',
+            {sparse: 1});
+        // For expiring login tokens
+        this.users._ensureIndex("services.resume.loginTokens.when", {sparse: 1});
+    }
+    ensurePasswordIndex() {
+        this.users._ensureIndex('services.email.verificationTokens.token',
+            {unique: 1, sparse: 1});
+        this.users._ensureIndex('services.password.reset.token',
+            {unique: 1, sparse: 1});
+    }
+}

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1,7 +1,6 @@
 var crypto = Npm.require('crypto');
-
 import {AccountsCommon} from "./accounts_common.js";
-
+import {AccountsProvider} from "./accounts_provider.js";
 /**
  * @summary Constructor for the `Accounts` namespace on the server.
  * @locus Server
@@ -14,8 +13,19 @@ export class AccountsServer extends AccountsCommon {
   // Note that this constructor is less likely to be instantiated multiple
   // times than the `AccountsClient` constructor, because a single server
   // can provide only one set of methods.
-  constructor(server) {
+  constructor(server, provider) {
     super();
+
+    // TODO: use the instance of provider passed in as argument, wire up connection for mongo
+    this.accountsProvider = new AccountsProvider(this.connection);
+
+    // TODO: determine how server-aware and backward compatible code should work
+    //       How does server-aware code get an instance of accountsProvider?
+    //       How does backward compatible code access accountsProvider through users?
+    //       Do we need to make Meteor.users abstract?
+    //       Do we need to add Meteor.accountsProvider global?
+    //
+    this.users = this.accountsProvider;
 
     this._server = server || Meteor.server;
     // Set up the server's methods, as if by calling Meteor.methods.
@@ -34,6 +44,7 @@ export class AccountsServer extends AccountsCommon {
     };
     this._initServerPublications();
 
+
     // connectionId -> {connection, loginToken}
     this._accountData = {};
 
@@ -48,7 +59,7 @@ export class AccountsServer extends AccountsCommon {
     // list of all registered handlers.
     this._loginHandlers = [];
 
-    setupUsersCollection(this.users);
+    setupUsersCollection(this.accountsProvider);
     setupDefaultLoginHandlers(this);
     setExpireTokensInterval(this);
 
@@ -82,6 +93,16 @@ export class AccountsServer extends AccountsCommon {
       throw new Error("Meteor.userId can only be invoked in method calls. Use this.userId in publish functions.");
     return currentInvocation.userId;
   }
+
+  /**
+   * @summary Get the current user record, or `null` if no user is logged in. A reactive data source.
+   * @locus Anywhere but publish functions
+   */
+  user() {
+    var userId = this.userId();
+    return userId ? this.accountsProvider.findById(userId) : null;
+  }
+
 
   ///
   /// LOGIN HOOKS
@@ -124,6 +145,7 @@ export class AccountsServer extends AccountsCommon {
   }
 };
 
+
 var Ap = AccountsServer.prototype;
 
 // Give each login hook callback a fresh cloned copy of the attempt
@@ -161,7 +183,6 @@ Ap._validateLogin = function (connection, attempt) {
   });
 };
 
-
 Ap._successfulLogin = function (connection, attempt) {
   this._onLoginHook.each(function (callback) {
     callback(cloneAttemptWithConnection(connection, attempt));
@@ -175,6 +196,7 @@ Ap._failedLogin = function (connection, attempt) {
     return true;
   });
 };
+
 
 
 ///
@@ -319,7 +341,7 @@ Ap._attemptLogin = function (
 
   var user;
   if (result.userId)
-    user = this.users.findOne(result.userId);
+    user = this.accountsProvider.findById(result.userId);
 
   var attempt = {
     type: result.type || "unknown",
@@ -398,7 +420,7 @@ Ap._reportLoginFailure = function (
   };
 
   if (result.userId) {
-    attempt.user = this.users.findOne(result.userId);
+    attempt.user = this.accountsProvider.findById(result.userId);
   }
 
   this._validateLogin(methodInvocation.connection, attempt);
@@ -489,6 +511,8 @@ Ap._runLoginHandlers = function (methodInvocation, options) {
 // in the process of becoming associated with hashed tokens and then
 // they'll get closed.
 Ap.destroyToken = function (userId, loginToken) {
+  this.accountsProvider.destroyToken(userId, loginToken);
+/*
   this.users.update(userId, {
     $pull: {
       "services.resume.loginTokens": {
@@ -499,6 +523,7 @@ Ap.destroyToken = function (userId, loginToken) {
       }
     }
   });
+  */
 };
 
 Ap._initServerMethods = function () {
@@ -534,6 +559,7 @@ Ap._initServerMethods = function () {
     this.setUserId(null);
   };
 
+
   // Delete all the current user's tokens and close all open connections logged
   // in as this user. Returns a fresh new login token that this client can
   // use. Tests set Accounts._noConnectionCloseDelayForTest to delete tokens
@@ -553,11 +579,9 @@ Ap._initServerMethods = function () {
   // @returns {Object} Object with token and tokenExpires keys.
   methods.logoutOtherClients = function () {
     var self = this;
-    var user = accounts.users.findOne(self.userId, {
-      fields: {
-        "services.resume.loginTokens": true
-      }
-    });
+  //  accounts.users.logoutOtherClients(self.userId);
+
+    var user = accounts.users.findSingleLoggedIn(self.userId);
     if (user) {
       // Save the current tokens in the database to be deleted in
       // CONNECTION_CLOSE_DELAY_MS ms. This gives other connections in the
@@ -567,6 +591,9 @@ Ap._initServerMethods = function () {
       var tokens = user.services.resume.loginTokens;
       var newToken = accounts._generateStampedLoginToken();
       var userId = self.userId;
+
+      accounts.users.saveTokenAndDeleteLater(userId, tokens, accounts._hashStampedToken(newToken));
+      /*
       accounts.users.update(userId, {
         $set: {
           "services.resume.loginTokensToDelete": tokens,
@@ -574,6 +601,7 @@ Ap._initServerMethods = function () {
         },
         $push: { "services.resume.loginTokens": accounts._hashStampedToken(newToken) }
       });
+      */
       Meteor.setTimeout(function () {
         // The observe on Meteor.users will take care of closing the connections
         // associated with `tokens`.
@@ -590,6 +618,7 @@ Ap._initServerMethods = function () {
     } else {
       throw new Meteor.Error("You are not logged in.");
     }
+
   };
 
   // Generates a new login token with the same expiration as the
@@ -602,6 +631,12 @@ Ap._initServerMethods = function () {
   //   tokenExpires: <expiration date> }.
   methods.getNewToken = function () {
     var self = this;
+    var newStampedToken = accounts.users.getNewToken(self.userId, accounts._getLoginToken(self.connection.id),
+    accounts._generateStampedLoginToken());
+    accounts._insertLoginToken(self.userId, newStampedToken);
+    return accounts._loginUser(self, self.userId, newStampedToken);
+/*
+
     var user = accounts.users.findOne(self.userId, {
       fields: { "services.resume.loginTokens": 1 }
     });
@@ -626,6 +661,7 @@ Ap._initServerMethods = function () {
     newStampedToken.when = currentStampedToken.when;
     accounts._insertLoginToken(self.userId, newStampedToken);
     return accounts._loginUser(self, self.userId, newStampedToken);
+    */
   };
 
   // Removes all tokens except the token associated with the current
@@ -633,6 +669,10 @@ Ap._initServerMethods = function () {
   // in. Returns nothing on success.
   methods.removeOtherTokens = function () {
     var self = this;
+    var loginToken = accounts._getLoginToken(self.connection.id);
+    // console.log("login Token is " + loginToken);
+    accounts.users.removeOtherTokens(self.userId, loginToken);
+/*
     if (! self.userId) {
       throw new Meteor.Error("You are not logged in.");
     }
@@ -642,6 +682,7 @@ Ap._initServerMethods = function () {
         "services.resume.loginTokens": { hashedToken: { $ne: currentToken } }
       }
     });
+    */
   };
 
   // Allow a one-time configuration for a login service. Modifications
@@ -700,16 +741,9 @@ Ap._initServerPublications = function () {
 
   // Publish the current user's record to the client.
   accounts._server.publish(null, function () {
+
     if (this.userId) {
-      return accounts.users.find({
-        _id: this.userId
-      }, {
-        fields: {
-          profile: 1,
-          username: 1,
-          emails: 1
-        }
-      });
+      return accounts.users.findCurrentUser(this.userId);
     } else {
       return null;
     }
@@ -818,6 +852,8 @@ Ap._hashStampedToken = function (stampedToken) {
 // logging in simultaneously has already inserted the new hashed
 // token.
 Ap._insertHashedLoginToken = function (userId, hashedToken, query) {
+  this.accountsProvider.insertHashedLoginToken(userId, hashedToken, query);
+/*
   query = query ? _.clone(query) : {};
   query._id = userId;
   this.users.update(query, {
@@ -825,6 +861,7 @@ Ap._insertHashedLoginToken = function (userId, hashedToken, query) {
       "services.resume.loginTokens": hashedToken
     }
   });
+  */
 };
 
 
@@ -839,11 +876,15 @@ Ap._insertLoginToken = function (userId, stampedToken, query) {
 
 
 Ap._clearAllLoginTokens = function (userId) {
+
+  this.accountsProvider.clearAllLoginTokens(userId);
+  /*
   this.users.update(userId, {
     $set: {
       'services.resume.loginTokens': []
     }
   });
+  */
 };
 
 // test hook
@@ -869,6 +910,8 @@ Ap._removeTokenFromConnection = function (connectionId) {
     }
   }
 };
+
+
 
 Ap._getLoginToken = function (connectionId) {
   return this._getAccountData(connectionId, 'loginToken');
@@ -906,10 +949,12 @@ Ap._setLoginToken = function (userId, connection, newToken) {
         return;
       }
 
+
       var foundMatchingUser;
       // Because we upgrade unhashed login tokens to hashed tokens at
       // login time, sessions will only be logged in with a hashed
       // token. Thus we only need to observe hashed tokens here.
+      /*
       var observe = self.users.find({
         _id: userId,
         'services.resume.loginTokens.hashedToken': newToken
@@ -924,6 +969,32 @@ Ap._setLoginToken = function (userId, connection, newToken) {
           // lying around.
         }
       });
+      */
+
+      var mongoUsersInstance = self.accountsProvider.getMongoUsersForReactiveWork();
+
+      if (!mongoUsersInstance) {
+        // throw an error, as this is not mongo backed
+        throw new Meteor.Error(403, "Database provider does not support reactivity.");
+      }
+
+
+      var observe = mongoUsersInstance.find({
+        _id: userId,
+        'services.resume.loginTokens.hashedToken': newToken
+      }, { fields: { _id: 1 } }).observeChanges({
+        added: function () {
+          foundMatchingUser = true;
+        },
+        removed: function () {
+          connection.close();
+          // The onClose callback for the connection takes care of
+          // cleaning up the observe handle and any other state we have
+          // lying around.
+        }
+      });
+
+
 
       // If the user ran another login or logout command we were waiting for the
       // defer or added to fire (ie, another call to _setLoginToken occurred),
@@ -964,14 +1035,16 @@ function defaultResumeLoginHandler(accounts, options) {
     return undefined;
 
   check(options.resume, String);
+  // console.log("in default RESUME handler (account_server.js)  -> options is " + JSON.stringify(options));
 
   var hashedToken = accounts._hashLoginToken(options.resume);
 
   // First look for just the new-style hashed login token, to avoid
   // sending the unhashed token to the database in a query if we don't
   // need to.
-  var user = accounts.users.findOne(
-    {"services.resume.loginTokens.hashedToken": hashedToken});
+
+  //  var user = accounts.users.findOne(
+  var user = accounts.users.findUserWithNewtoken( hashedToken);
 
   if (! user) {
     // If we didn't find the hashed login token, try also looking for
@@ -979,12 +1052,10 @@ function defaultResumeLoginHandler(accounts, options) {
     // the old-style token OR the new-style token, because another
     // client connection logging in simultaneously might have already
     // converted the token.
-    user = accounts.users.findOne({
-      $or: [
-        {"services.resume.loginTokens.hashedToken": hashedToken},
-        {"services.resume.loginTokens.token": options.resume}
-      ]
-    });
+    // user = accounts.users.findUserWithNewOrOld(hashedToken);
+
+     user = accounts.users.findUserWithNewOrOld(hashedToken, options.resume);
+    // console.log("in default RESUME, cannot find new token - trying both => user is " + JSON.stringify(user));
   }
 
   if (! user)
@@ -1022,6 +1093,8 @@ function defaultResumeLoginHandler(accounts, options) {
     // after we read it).  Using $addToSet avoids getting an index
     // error if another client logging in simultaneously has already
     // inserted the new hashed token.
+    accounts.users.addNewHashedTokenIfOldUnhashedStillExists(user._id, options.resume, hashedToken, token.when);
+    /*
     accounts.users.update(
       {
         _id: user._id,
@@ -1034,15 +1107,21 @@ function defaultResumeLoginHandler(accounts, options) {
         }
       }}
     );
+    */
 
     // Remove the old token *after* adding the new, since otherwise
     // another client trying to login between our removing the old and
     // adding the new wouldn't find a token to login with.
+    accounts.users.removeOldTokenAfterAddingNew(user._id, options.resume);
+    /*
     accounts.users.update(user._id, {
       $pull: {
         "services.resume.loginTokens": { "token": options.resume }
       }
     });
+    */
+    var tpSingle = accounts.users.findById(user._id);
+    // console.log("AFTER REPLACEMENT - here is what it looks like " + JSON.stringify(tpSingle));
   }
 
   return {
@@ -1084,6 +1163,9 @@ Ap._expireTokens = function (oldestValidDate, userId) {
 
   oldestValidDate = oldestValidDate ||
     (new Date(new Date() - tokenLifetimeMs));
+
+  this.accountsProvider.expireTokens(oldestValidDate, userId);
+  /*
   var userFilter = userId ? {_id: userId} : {};
 
 
@@ -1104,9 +1186,10 @@ Ap._expireTokens = function (oldestValidDate, userId) {
       }
     }
   }, { multi: true });
+  */
   // The observe on Meteor.users will take care of closing connections for
   // expired tokens.
-};
+  };
 
 // @override from accounts_common.js
 Ap.config = function (options) {
@@ -1245,7 +1328,11 @@ Ap.insertUserDoc = function (options, user) {
       throw new Meteor.Error(403, "User validation failed");
   });
 
-  var userId;
+//  var userId;
+
+  return this.accountsProvider.insertUser(fullUser);
+
+  /*
   try {
     userId = this.users.insert(fullUser);
   } catch (e) {
@@ -1261,6 +1348,7 @@ Ap.insertUserDoc = function (options, user) {
     throw e;
   }
   return userId;
+  */
 };
 
 // Helper function: returns false if email does not match company domain from
@@ -1321,6 +1409,7 @@ Ap.updateOrCreateUserFromExternalService = function (
   serviceData,
   options
 ) {
+
   options = _.clone(options || {});
 
   if (serviceName === "password" || serviceName === "resume")
@@ -1350,7 +1439,10 @@ Ap.updateOrCreateUserFromExternalService = function (
     selector[serviceIdKey] = serviceData.id;
   }
 
-  var user = this.users.findOne(selector);
+  // ignoring Twitter for now
+  var user = this.accountsProvider.findByService(selector);
+
+  //var user = this.users.findByService(serviceIdKey, serviceData.id);
 
   if (user) {
     pinEncryptedFieldsToUser(serviceData, user._id);
@@ -1367,9 +1459,7 @@ Ap.updateOrCreateUserFromExternalService = function (
 
     // XXX Maybe we should re-use the selector above and notice if the update
     //     touches nothing?
-    this.users.update(user._id, {
-      $set: setAttrs
-    });
+    this.accountsProvider.updateAttributes(user._id, setAttrs);
 
     return {
       type: serviceName,
@@ -1386,12 +1476,15 @@ Ap.updateOrCreateUserFromExternalService = function (
       userId: this.insertUserDoc(options, user)
     };
   }
-};
+
+}
 
 function setupUsersCollection(users) {
+  users.setupUsersCollection();
   ///
   /// RESTRICTING WRITES TO USER OBJECTS
   ///
+  /*
   users.allow({
     // clients can modify the profile field of their own document, and
     // nothing else.
@@ -1424,6 +1517,7 @@ function setupUsersCollection(users) {
                      { sparse: 1 });
   // For expiring login tokens
   users._ensureIndex("services.resume.loginTokens.when", { sparse: 1 });
+  */
 }
 
 ///
@@ -1431,6 +1525,9 @@ function setupUsersCollection(users) {
 ///
 
 Ap._deleteSavedTokensForUser = function (userId, tokensToDelete) {
+
+  this.accountsProvider.deleteSavedTokens(userId, tokensToDelete);
+/*
   if (tokensToDelete) {
     this.users.update(userId, {
       $unset: {
@@ -1442,6 +1539,7 @@ Ap._deleteSavedTokensForUser = function (userId, tokensToDelete) {
       }
     });
   }
+  */
 };
 
 Ap._deleteSavedTokensForAllUsersOnStartup = function () {
@@ -1454,6 +1552,9 @@ Ap._deleteSavedTokensForAllUsersOnStartup = function () {
   // that would give a lot of power to an attacker with a stolen login
   // token and the ability to crash the server.
   Meteor.startup(function () {
+
+    self.accountsProvider.deleteSavedTokensforAllUsers();
+    /*
     self.users.find({
       "services.resume.haveLoginTokensToDelete": true
     }, {
@@ -1464,5 +1565,7 @@ Ap._deleteSavedTokensForAllUsersOnStartup = function () {
         user.services.resume.loginTokensToDelete
       );
     });
+    */
   });
 };
+

--- a/packages/accounts-base/accounts_tests.js
+++ b/packages/accounts-base/accounts_tests.js
@@ -27,7 +27,7 @@ Tinytest.add('accounts - validateNewUser gets passed user with _id', function (t
   test.isTrue(newUserId in idsInValidateNewUser);
 });
 
-Tinytest.add('accounts - updateOrCreateUserFromExternalService - Facebook', function (test) {
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - compatibility with mongo provider - Facebook', function (test) {
   var facebookId = Random.id();
 
   // create an account with facebook
@@ -58,7 +58,38 @@ Tinytest.add('accounts - updateOrCreateUserFromExternalService - Facebook', func
   Meteor.users.removeById(uid1);
 });
 
-Tinytest.add('accounts - updateOrCreateUserFromExternalService - Weibo', function (test) {
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Facebook', function (test) {
+    var facebookId = Random.id();
+
+    // create an account with facebook
+    var uid1 = Accounts.updateOrCreateUserFromExternalService(
+        'facebook', {id: facebookId, monkey: 42}, {profile: {foo: 1}}).id;
+    //  var users = Meteor.users.find({"services.facebook.id": facebookId}).fetch();
+    var users = Meteor.dataProvider.findUsersByService({"services.facebook.id": facebookId});
+    test.length(users, 1);
+    test.equal(users[0].profile.foo, 1);
+    test.equal(users[0].services.facebook.monkey, 42);
+
+    // create again with the same id, see that we get the same user.
+    // it should update services.facebook but not profile.
+    var uid2 = Accounts.updateOrCreateUserFromExternalService(
+        'facebook', {id: facebookId, llama: 50},
+        {profile: {foo: 1000, bar: 2}}).id;
+    test.equal(uid1, uid2);
+    users = Meteor.dataProvider.findUsersByService({"services.facebook.id": facebookId});
+    test.length(users, 1);
+    test.equal(users[0].profile.foo, 1);
+    test.equal(users[0].profile.bar, undefined);
+    test.equal(users[0].services.facebook.llama, 50);
+    // make sure we *don't* lose values not passed this call to
+    // updateOrCreateUserFromExternalService
+    test.equal(users[0].services.facebook.monkey, 42);
+
+    // cleanup
+    Meteor.dataProvider.removeById(uid1);
+});
+
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - compatibility with mongo provider - Weibo', function (test) {
   var weiboId1 = Random.id();
   var weiboId2 = Random.id();
 
@@ -79,9 +110,30 @@ Tinytest.add('accounts - updateOrCreateUserFromExternalService - Weibo', functio
   Meteor.users.removeById(uid1);
   Meteor.users.removeById(uid2);
 });
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Weibo', function (test) {
+    var weiboId1 = Random.id();
+    var weiboId2 = Random.id();
+
+    // users that have different service ids get different users
+    var uid1 = Accounts.updateOrCreateUserFromExternalService(
+        'weibo', {id: weiboId1}, {profile: {foo: 1}}).id;
+    var uid2 = Accounts.updateOrCreateUserFromExternalService(
+        'weibo', {id: weiboId2}, {profile: {bar: 2}}).id;
+    var users = Meteor.dataProvider.findUsersInServices([weiboId1, weiboId2]);
+    test.equal(users.count(), 2);
+    //  console.log(JSON.stringify(Meteor.users.findUsersByService({"services.weibo.id": weiboId1})));
+    test.equal(Meteor.dataProvider.findUsersByService({"services.weibo.id": weiboId1})[0].profile.foo, 1);
+    test.equal(Meteor.dataProvider.findUsersByService({"services.weibo.id": weiboId1})[0].emails, undefined);
+    test.equal(Meteor.dataProvider.findUsersByService({"services.weibo.id": weiboId2})[0].profile.bar, 2);
+    test.equal(Meteor.dataProvider.findUsersByService({"services.weibo.id": weiboId2})[0].emails, undefined);
+
+    // cleanupr
+    Meteor.dataProvider.removeById(uid1);
+    Meteor.dataProvider.removeById(uid2);
+});
 
 
-Tinytest.add('accounts - updateOrCreateUserFromExternalService - Twitter', function (test) {
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - compatibility with mongo provider - Twitter', function (test) {
   var twitterIdOld = parseInt(Random.hexString(4), 16);
   var twitterIdNew = ''+twitterIdOld;
 
@@ -106,8 +158,32 @@ Tinytest.add('accounts - updateOrCreateUserFromExternalService - Twitter', funct
   Meteor.users.removeById(uid1);
 });
 
+Tinytest.add('accounts - updateOrCreateUserFromExternalService - Twitter', function (test) {
+    var twitterIdOld = parseInt(Random.hexString(4), 16);
+    var twitterIdNew = ''+twitterIdOld;
 
-Tinytest.add('accounts - insertUserDoc username', function (test) {
+    // create an account with twitter using the old ID format of integer
+    var uid1 = Accounts.updateOrCreateUserFromExternalService(
+        'twitter', {id: twitterIdOld, monkey: 42}, {profile: {foo: 1}}).id;
+    var users = Meteor.dataProvider.findUsersByService({"services.twitter.id": twitterIdOld});
+    test.length(users, 1);
+    test.equal(users[0].profile.foo, 1);
+    test.equal(users[0].services.twitter.monkey, 42);
+
+    // Update the account with the new ID format of string
+    // test that the existing user is found, and that the ID
+    // gets updated to a string value
+    var uid2 = Accounts.updateOrCreateUserFromExternalService(
+        'twitter', {id: twitterIdNew, monkey: 42}, {profile: {foo: 1}}).id;
+    test.equal(uid1, uid2);
+    users = Meteor.dataProvider.findUsersByService({"services.twitter.id": twitterIdNew});
+    test.length(users, 1);
+
+    // cleanup
+    Meteor.dataProvider.removeById(uid1);
+});
+
+Tinytest.add('accounts - compatibility with mongo provider - insertUserDoc username' , function (test) {
   var userIn = {
     username: Random.id()
   };
@@ -135,7 +211,36 @@ Tinytest.add('accounts - insertUserDoc username', function (test) {
   Meteor.users.removeById(userId);
 });
 
-Tinytest.add('accounts - insertUserDoc email', function (test) {
+Tinytest.add('accounts - insertUserDoc username', function (test) {
+    var userIn = {
+        username: Random.id()
+    };
+
+    // user does not already exist. create a user object with fields set.
+    var userId = Accounts.insertUserDoc(
+        {profile: {name: 'Foo Bar'}},
+        userIn
+    );
+    var userOut = Meteor.dataProvider.findById(userId);
+
+    test.equal(typeof userOut.createdAt, 'object');
+    test.equal(userOut.profile.name, 'Foo Bar');
+    test.equal(userOut.username, userIn.username);
+
+    // run the hook again. now the user exists, so it throws an error.
+    test.throws(function () {
+        Accounts.insertUserDoc(
+            {profile: {name: 'Foo Bar'}},
+            userIn
+        );
+    }, 'Username already exists.');
+
+    // cleanup
+    Meteor.dataProvider.removeById(userId);
+});
+
+
+Tinytest.add('accounts - compatibility with mongo provider - insertUserDoc email', function (test) {
   var email1 = Random.id();
   var email2 = Random.id();
   var email3 = Random.id();
@@ -190,8 +295,63 @@ Tinytest.add('accounts - insertUserDoc email', function (test) {
   Meteor.users.removeById(userId3);
 });
 
+Tinytest.add('accounts - insertUserDoc email', function (test) {
+    var email1 = Random.id();
+    var email2 = Random.id();
+    var email3 = Random.id();
+    var userIn = {
+        emails: [{address: email1, verified: false},
+            {address: email2, verified: true}]
+    };
+
+    // user does not already exist. create a user object with fields set.
+    var userId = Accounts.insertUserDoc(
+        {profile: {name: 'Foo Bar'}},
+        userIn
+    );
+    var userOut = Meteor.dataProvider.findById(userId);
+
+    test.equal(typeof userOut.createdAt, 'object');
+    test.equal(userOut.profile.name, 'Foo Bar');
+    test.equal(userOut.emails, userIn.emails);
+
+    // run the hook again with the exact same emails.
+    // run the hook again. now the user exists, so it throws an error.
+    test.throws(function () {
+        Accounts.insertUserDoc(
+            {profile: {name: 'Foo Bar'}},
+            userIn
+        );
+    }, 'Email already exists.');
+
+    // now with only one of them.
+    test.throws(function () {
+        Accounts.insertUserDoc(
+            {}, {emails: [{address: email1}]}
+        );
+    }, 'Email already exists.');
+
+    test.throws(function () {
+        Accounts.insertUserDoc(
+            {}, {emails: [{address: email2}]}
+        );
+    }, 'Email already exists.');
+
+
+    // a third email works.
+    var userId3 = Accounts.insertUserDoc(
+        {}, {emails: [{address: email3}]}
+    );
+    var user3 = Meteor.dataProvider.findById(userId3);
+    test.equal(typeof user3.createdAt, 'object');
+
+    // cleanup
+    Meteor.dataProvider.removeById(userId);
+    Meteor.dataProvider.removeById(userId3);
+});
+
 // More token expiration tests are in accounts-password
-Tinytest.addAsync('accounts - expire numeric token', function (test, onComplete) {
+Tinytest.addAsync('accounts - compatibility with mongo provider - expire numeric token', function (test, onComplete) {
   var userIn = { username: Random.id() };
   var userId = Accounts.insertUserDoc({ profile: {
     name: 'Foo Bar'
@@ -219,12 +379,39 @@ Tinytest.addAsync('accounts - expire numeric token', function (test, onComplete)
   Accounts._expireTokens(new Date(), userId);
 });
 
+Tinytest.addAsync('accounts - expire numeric token', function (test, onComplete) {
+    var userIn = { username: Random.id() };
+    var userId = Accounts.insertUserDoc({ profile: {
+        name: 'Foo Bar'
+    } }, userIn);
+    var date = new Date(new Date() - 5000);
+
+    Meteor.dataProvider.setResumeTokens(userId,  [{
+        hashedToken: Random.id(),
+        when: date
+    }, {
+        hashedToken: Random.id(),
+        when: +date
+    }]);
+
+    var reactiveUsers = Meteor.dataProvider.getMongoUsersForReactiveWork();
+    var observe = reactiveUsers.find(userId).observe({
+        changed: function (newUser) {
+            if (newUser.services && newUser.services.resume &&
+                _.isEmpty(newUser.services.resume.loginTokens)) {
+                observe.stop();
+                onComplete();
+            }
+        }
+    });
+    Accounts._expireTokens(new Date(), userId);
+});
 
 
 // Login tokens used to be stored unhashed in the database.  We want
 // to make sure users can still login after upgrading.
 var insertUnhashedLoginToken = function (userId, stampedToken) {
-  Meteor.users.insertLoginToken(
+  Meteor.dataProvider.insertLoginToken(
     userId, stampedToken
   );
 };
@@ -248,7 +435,7 @@ Tinytest.addAsync('accounts - login token', function (test, onComplete) {
   var userId2 = Accounts.insertUserDoc({}, {username: Random.id()});
   insertUnhashedLoginToken(userId2, Accounts._generateStampedLoginToken());
 
-  var stolenToken = Meteor.users.findById(userId2).services.resume.loginTokens[0].token;
+  var stolenToken = Meteor.dataProvider.findById(userId2).services.resume.loginTokens[0].token;
   test.isTrue(stolenToken);
   connection = DDP.connect(Meteor.absoluteUrl());
   connection.call('login', {resume: stolenToken});
@@ -257,7 +444,7 @@ Tinytest.addAsync('accounts - login token', function (test, onComplete) {
   // Now do the same thing, this time with a stolen hashed token.
   var userId3 = Accounts.insertUserDoc({}, {username: Random.id()});
   Accounts._insertLoginToken(userId3, Accounts._generateStampedLoginToken());
-  stolenToken = Meteor.users.findById(userId3).services.resume.loginTokens[0].hashedToken;
+  stolenToken = Meteor.dataProvider.findById(userId3).services.resume.loginTokens[0].hashedToken;
   test.isTrue(stolenToken);
   connection = DDP.connect(Meteor.absoluteUrl());
   // evil plan foiled
@@ -280,7 +467,7 @@ Tinytest.addAsync('accounts - login token', function (test, onComplete) {
   connection.disconnect();
 
   // The token is no longer available to be stolen.
-  stolenToken = Meteor.users.findById(userId4).services.resume.loginTokens[0].token;
+  stolenToken = Meteor.dataProvider.findById(userId4).services.resume.loginTokens[0].token;
   test.isFalse(stolenToken);
 
   // After the upgrade, the client can still login with their original
@@ -291,6 +478,72 @@ Tinytest.addAsync('accounts - login token', function (test, onComplete) {
 
   onComplete();
 });
+
+
+// reactive test
+Tinytest.addAsync('accounts - compatibility with mongo provider - login token', function (test, onComplete) {
+    // Test that we can login when the database contains a leftover
+    // old style unhashed login token.
+    var userId1 = Accounts.insertUserDoc({}, {username: Random.id()});
+    //  console.log("userId1 is " + userId1);
+    var stampedToken = Accounts._generateStampedLoginToken();
+    //  console.log("stampedToken is " + JSON.stringify(stampedToken));
+    insertUnhashedLoginToken(userId1, stampedToken);
+
+    var connection = DDP.connect(Meteor.absoluteUrl());
+    connection.call('login', {resume: stampedToken.token});
+    connection.disconnect();
+
+    // Steal the unhashed token from the database and use it to login.
+    // This is a sanity check so that when we *can't* login with a
+    // stolen *hashed* token, we know it's not a problem with the test.
+    var userId2 = Accounts.insertUserDoc({}, {username: Random.id()});
+    insertUnhashedLoginToken(userId2, Accounts._generateStampedLoginToken());
+
+    var stolenToken = Meteor.users.findById(userId2).services.resume.loginTokens[0].token;
+    test.isTrue(stolenToken);
+    connection = DDP.connect(Meteor.absoluteUrl());
+    connection.call('login', {resume: stolenToken});
+    connection.disconnect();
+
+    // Now do the same thing, this time with a stolen hashed token.
+    var userId3 = Accounts.insertUserDoc({}, {username: Random.id()});
+    Accounts._insertLoginToken(userId3, Accounts._generateStampedLoginToken());
+    stolenToken = Meteor.users.findById(userId3).services.resume.loginTokens[0].hashedToken;
+    test.isTrue(stolenToken);
+    connection = DDP.connect(Meteor.absoluteUrl());
+    // evil plan foiled
+    test.throws(
+        function () {
+            connection.call('login', {resume: stolenToken});
+        },
+        /You\'ve been logged out by the server/
+    );
+    connection.disconnect();
+
+    // Old style unhashed tokens are replaced by hashed tokens when
+    // encountered.  This means that after someone logins once, the
+    // old unhashed token is no longer available to be stolen.
+    var userId4 = Accounts.insertUserDoc({}, {username: Random.id()});
+    var stampedToken = Accounts._generateStampedLoginToken();
+    insertUnhashedLoginToken(userId4, stampedToken);
+    connection = DDP.connect(Meteor.absoluteUrl());
+    connection.call('login', {resume: stampedToken.token});
+    connection.disconnect();
+
+    // The token is no longer available to be stolen.
+    stolenToken = Meteor.users.findById(userId4).services.resume.loginTokens[0].token;
+    test.isFalse(stolenToken);
+
+    // After the upgrade, the client can still login with their original
+    // unhashed login token.
+    connection = DDP.connect(Meteor.absoluteUrl());
+    connection.call('login', {resume: stampedToken.token});
+    connection.disconnect();
+
+    onComplete();
+});
+
 
 Tinytest.addAsync(
   'accounts - connection data cleaned up',

--- a/packages/accounts-base/client_main.js
+++ b/packages/accounts-base/client_main.js
@@ -12,6 +12,7 @@ Accounts = new AccountsClient();
  * @summary A [Mongo.Collection](#collections) containing user documents.
  * @locus Anywhere
  * @type {Mongo.Collection}
+ * @importFromPackage meteor
  */
 Meteor.users = Accounts.users;
 

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "A user account system",
-  version: "1.2.3-beta.16"
+  version: "1.2.7"
 });
 
 Package.onUse(function (api) {

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -1,12 +1,23 @@
 import {AccountsServer} from "./accounts_server.js";
 import "./accounts_rate_limit.js";
 import "./url_server.js";
+import {AccountsProvider} from "./accounts_provider";
+
+
 
 /**
  * @namespace Accounts
  * @summary The namespace for all server-side accounts-related methods.
  */
 Accounts = new AccountsServer(Meteor.server);
+
+// TODO: determine how server-aware and backward compatible code should work
+//       How does server-aware code get an instance of accountsProvider?
+//       How does backward compatible code access accountsProvider through users?
+//       Do we need to make Meteor.users abstract?
+//       Do we need to add Meteor.accountsProvider global?
+//
+
 
 // Users table. Don't use the normal autopublish, since we want to hide
 // some fields. Code to autopublish this is in accounts_server.js.
@@ -16,8 +27,9 @@ Accounts = new AccountsServer(Meteor.server);
  * @summary A [Mongo.Collection](#collections) containing user documents.
  * @locus Anywhere
  * @type {Mongo.Collection}
- */
-Meteor.users = Accounts.users;
+ * @importFromPackage meteor
+*/
+Meteor.users = Accounts.accountsProvider;  //Accounts.users;
 
 export {
   // Since this file is the main module for the server version of the

--- a/packages/accounts-base/server_main.js
+++ b/packages/accounts-base/server_main.js
@@ -15,7 +15,7 @@ Accounts = new AccountsServer(Meteor.server);
 //       How does server-aware code get an instance of accountsProvider?
 //       How does backward compatible code access accountsProvider through users?
 //       Do we need to make Meteor.users abstract?
-//       Do we need to add Meteor.accountsProvider global?
+//       Do we need to add Meteor.dataProvider global?
 //
 
 
@@ -30,6 +30,7 @@ Accounts = new AccountsServer(Meteor.server);
  * @importFromPackage meteor
 */
 Meteor.users = Accounts.accountsProvider;  //Accounts.users;
+Meteor.dataProvider = Accounts.accountsProvider;
 
 export {
   // Since this file is the main module for the server version of the

--- a/packages/accounts-password/email_templates.js
+++ b/packages/accounts-password/email_templates.js
@@ -16,6 +16,7 @@ Thanks.
 /**
  * @summary Options to customize emails sent from the Accounts system.
  * @locus Server
+ * @importFromPackage accounts-base
  */
 Accounts.emailTemplates = {
   from: "Meteor Accounts <no-reply@meteor.com>",

--- a/packages/accounts-password/email_tests_setup.js
+++ b/packages/accounts-password/email_tests_setup.js
@@ -45,8 +45,9 @@ Meteor.methods({
 
   addEmailForTestAndVerify: function (email) {
     check(email, String);
-
-    Meteor.users.addEmailVerified(this.userId, email, false);
+    
+    // only called from server-side
+    Meteor.dataProvider.addEmailVerified(this.userId, email, false);
     /*
     Meteor.users.update(
       {_id: this.userId},
@@ -59,6 +60,6 @@ Meteor.methods({
     check(email, String);
     var userId = Accounts.createUser({email: email});
     Accounts.sendEnrollmentEmail(userId);
-    return Meteor.users.findById(userId);
+    return Meteor.dataProvider.findById(userId);
   }
 });

--- a/packages/accounts-password/email_tests_setup.js
+++ b/packages/accounts-password/email_tests_setup.js
@@ -45,9 +45,13 @@ Meteor.methods({
 
   addEmailForTestAndVerify: function (email) {
     check(email, String);
+
+    Meteor.users.addEmailVerified(this.userId, email, false);
+    /*
     Meteor.users.update(
       {_id: this.userId},
       {$push: {emails: {address: email, verified: false}}});
+      */
     Accounts.sendVerificationEmail(this.userId, email);
   },
 
@@ -55,6 +59,6 @@ Meteor.methods({
     check(email, String);
     var userId = Accounts.createUser({email: email});
     Accounts.sendEnrollmentEmail(userId);
-    return Meteor.users.findOne(userId);
+    return Meteor.users.findById(userId);
   }
 });

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -1,10 +1,10 @@
 Package.describe({
   summary: "Password support for accounts",
-  version: "1.1.5-beta.16"
+  version: "1.1.8"
 });
 
 Package.onUse(function(api) {
-  api.use('npm-bcrypt@=0.7.8_2');
+  api.use('npm-bcrypt@0.8.5');
 
   api.use([
     'accounts-base',

--- a/packages/accounts-password/password_client.js
+++ b/packages/accounts-password/password_client.js
@@ -19,6 +19,7 @@
  * @param {Function} [callback] Optional callback.
  *   Called with no arguments on success, or with a single `Error` argument
  *   on failure.
+ * @importFromPackage meteor
  */
 Meteor.loginWithPassword = function (selector, password, callback) {
   if (typeof selector === 'string')
@@ -109,6 +110,7 @@ var srpUpgradePath = function (options, callback) {
  * @param {String} options.password The user's password. This is __not__ sent in plain text over the wire.
  * @param {Object} options.profile The user's profile, typically including the `name` field.
  * @param {Function} [callback] Client only, optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ * @importFromPackage accounts-base
  */
 Accounts.createUser = function (options, callback) {
   options = _.clone(options); // we'll be modifying options
@@ -144,6 +146,7 @@ Accounts.createUser = function (options, callback) {
  * @param {String} oldPassword The user's current password. This is __not__ sent in plain text over the wire.
  * @param {String} newPassword A new password for the user. This is __not__ sent in plain text over the wire.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ * @importFromPackage accounts-base
  */
 Accounts.changePassword = function (oldPassword, newPassword, callback) {
   if (!Meteor.user()) {
@@ -206,6 +209,7 @@ Accounts.changePassword = function (oldPassword, newPassword, callback) {
  * @param {Object} options
  * @param {String} options.email The email address to send a password reset link.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ * @importFromPackage accounts-base
  */
 Accounts.forgotPassword = function(options, callback) {
   if (!options.email)
@@ -226,6 +230,7 @@ Accounts.forgotPassword = function(options, callback) {
  * @param {String} token The token retrieved from the reset password URL.
  * @param {String} newPassword A new password for the user. This is __not__ sent in plain text over the wire.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ * @importFromPackage accounts-base
  */
 Accounts.resetPassword = function(token, newPassword, callback) {
   check(token, String);
@@ -253,6 +258,7 @@ Accounts.resetPassword = function(token, newPassword, callback) {
  * @locus Client
  * @param {String} token The token retrieved from the verification URL.
  * @param {Function} [callback] Optional callback. Called with no arguments on success, or with a single `Error` argument on failure.
+ * @importFromPackage accounts-base
  */
 Accounts.verifyEmail = function(token, callback) {
   if (!token)

--- a/packages/accounts-password/password_server.js
+++ b/packages/accounts-password/password_server.js
@@ -79,9 +79,10 @@ var checkPassword = Accounts._checkPassword;
 
 Accounts._findUserByQuery = function (query) {
   var user = null;
-
+//console.log("query is " + JSON.stringify(query));
   if (query.id) {
-    user = Meteor.users.findOne({ _id: query.id });
+    user = Meteor.users.findById( query.id );
+    // console.log("got user ==> " + JSON.stringify(user));
   } else {
     var fieldName;
     var fieldValue;
@@ -96,11 +97,17 @@ Accounts._findUserByQuery = function (query) {
     }
     var selector = {};
     selector[fieldName] = fieldValue;
-    user = Meteor.users.findOne(selector);
+    //user = Meteor.users.findOne(selector);
+    //**
+
+    //console.log("selector first is " + JSON.stringify(selector));
+    user = Meteor.users.findOneBySelector(selector);
     // If user is not found, try a case insensitive lookup
     if (!user) {
       selector = selectorForFastCaseInsensitiveLookup(fieldName, fieldValue);
-      var candidateUsers = Meteor.users.find(selector).fetch();
+      // console.log("selector is " + JSON.stringify(selector));
+      var candidateUsers = Meteor.users.findBySelector(selector).fetch();
+      // console.log("candidates are " + JSON.stringify(candidateUsers));
       // No match if multiple candidates are found
       if (candidateUsers.length === 1) {
         user = candidateUsers[0];
@@ -119,6 +126,7 @@ Accounts._findUserByQuery = function (query) {
  * @locus Server
  * @param {String} username The username to look for
  * @returns {Object} A user if found, else null
+ * @importFromPackage accounts-base
  */
 Accounts.findUserByUsername = function (username) {
   return Accounts._findUserByQuery({
@@ -134,6 +142,7 @@ Accounts.findUserByUsername = function (username) {
  * @locus Server
  * @param {String} email The email address to look for
  * @returns {Object} A user if found, else null
+ * @importFromPackage accounts-base
  */
 Accounts.findUserByEmail = function (email) {
   return Accounts._findUserByQuery({
@@ -154,15 +163,15 @@ var selectorForFastCaseInsensitiveLookup = function (fieldName, string) {
   // Performance seems to improve up to 4 prefix characters
   var prefix = string.substring(0, Math.min(string.length, 4));
   var orClause = _.map(generateCasePermutationsForString(prefix),
-    function (prefixPermutation) {
-      var selector = {};
-      selector[fieldName] =
-        new RegExp('^' + Meteor._escapeRegExp(prefixPermutation));
-      return selector;
-    });
+      function (prefixPermutation) {
+        var selector = {};
+        selector[fieldName] =
+            new RegExp('^' + Meteor._escapeRegExp(prefixPermutation));
+        return selector;
+      });
   var caseInsensitiveClause = {};
   caseInsensitiveClause[fieldName] =
-    new RegExp('^' + Meteor._escapeRegExp(string) + '$', 'i')
+      new RegExp('^' + Meteor._escapeRegExp(string) + '$', 'i')
   return {$and: [{$or: orClause}, caseInsensitiveClause]};
 }
 
@@ -191,7 +200,8 @@ var checkForCaseInsensitiveDuplicates = function (fieldName, displayName, fieldV
   var skipCheck = _.has(Accounts._skipCaseInsensitiveChecksForTest, fieldValue);
 
   if (fieldValue && !skipCheck) {
-    var matchedUsers = Meteor.users.find(
+    //*** mod
+    var matchedUsers = Meteor.users.findBySelector(
       selectorForFastCaseInsensitiveLookup(fieldName, fieldValue)).fetch();
 
     if (matchedUsers.length > 0 &&
@@ -204,6 +214,7 @@ var checkForCaseInsensitiveDuplicates = function (fieldName, displayName, fieldV
     }
   }
 };
+
 
 // XXX maybe this belongs in the check package
 var NonEmptyString = Match.Where(function (x) {
@@ -249,7 +260,7 @@ Accounts.registerLoginHandler("password", function (options) {
     user: userQueryValidator,
     password: passwordValidator
   });
-
+// console.log("in password -> options is " + JSON.stringify(options));
 
   var user = Accounts._findUserByQuery(options.user);
   if (!user)
@@ -316,6 +327,7 @@ Accounts.registerLoginHandler("password", function (options) {
     srp: String,
     password: passwordValidator
   });
+  // console.log("in password COMPAT 0.8.1.3 -> options is " + JSON.stringify(options));
 
   var user = Accounts._findUserByQuery(options.user);
   if (!user)
@@ -345,6 +357,8 @@ Accounts.registerLoginHandler("password", function (options) {
 
   // Upgrade to bcrypt on successful login.
   var salted = hashPassword(options.password);
+  Meteor.users.updateToBcrypt(user._id, salted);
+  /*
   Meteor.users.update(
     user._id,
     {
@@ -352,7 +366,7 @@ Accounts.registerLoginHandler("password", function (options) {
       $set: { 'services.password.bcrypt': salted }
     }
   );
-
+  */
   return {userId: user._id};
 });
 
@@ -368,12 +382,13 @@ Accounts.registerLoginHandler("password", function (options) {
  * @locus Server
  * @param {String} userId The ID of the user to update.
  * @param {String} newUsername A new username for the user.
+ * @importFromPackage accounts-base
  */
 Accounts.setUsername = function (userId, newUsername) {
   check(userId, NonEmptyString);
   check(newUsername, NonEmptyString);
 
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Meteor.Error(403, "User not found");
 
@@ -381,16 +396,20 @@ Accounts.setUsername = function (userId, newUsername) {
 
   // Perform a case insensitive check fro duplicates before update
   checkForCaseInsensitiveDuplicates('username', 'Username', newUsername, user._id);
-
+  Meteor.users.setUsername(user._id, newUsername);
+  /*
   Meteor.users.update({_id: user._id}, {$set: {username: newUsername}});
-
+*/
   // Perform another check after update, in case a matching user has been
   // inserted in the meantime
   try {
     checkForCaseInsensitiveDuplicates('username', 'Username', newUsername, user._id);
   } catch (ex) {
     // Undo update if the check fails
+    Meteor.users.setUsername(user._id, oldUsername);
+    /*
     Meteor.users.update({_id: user._id}, {$set: {username: oldUsername}});
+    */
     throw ex;
   }
 };
@@ -417,7 +436,7 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
   if (!this.userId)
     throw new Meteor.Error(401, "Must be logged in");
 
-  var user = Meteor.users.findOne(this.userId);
+  var user = Meteor.users.findById(this.userId);
   if (!user)
     throw new Meteor.Error(403, "User not found");
 
@@ -443,6 +462,9 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
   // be tricky, so we'll settle for just replacing all tokens other than
   // the one for the current connection.
   var currentToken = Accounts._getLoginToken(this.connection.id);
+
+  Meteor.users.replaceAllTokensOtherThanCurrentConnection(this.userId, hashed, currentToken);
+  /*
   Meteor.users.update(
     { _id: this.userId },
     {
@@ -453,7 +475,7 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
       $unset: { 'services.password.reset': 1 }
     }
   );
-
+  */
   return {passwordChanged: true};
 }});
 
@@ -467,14 +489,17 @@ Meteor.methods({changePassword: function (oldPassword, newPassword) {
  * @param {String} newPassword A new password for the user.
  * @param {Object} [options]
  * @param {Object} options.logout Logout all current connections with this userId (default: true)
+ * @importFromPackage accounts-base
  */
 Accounts.setPassword = function (userId, newPlaintextPassword, options) {
   options = _.extend({logout: true}, options);
 
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Meteor.Error(403, "User not found");
 
+  Meteor.users.forceChangePassword(user._id, hashPassword(newPlaintextPassword), options.logout);
+  /*
   var update = {
     $unset: {
       'services.password.srp': 1, // XXX COMPAT WITH 0.8.1.3
@@ -488,6 +513,7 @@ Accounts.setPassword = function (userId, newPlaintextPassword, options) {
   }
 
   Meteor.users.update({_id: user._id}, update);
+  */
 };
 
 
@@ -520,10 +546,12 @@ Meteor.methods({forgotPassword: function (options) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
+ * @importFromPackage accounts-base
  */
 Accounts.sendResetPasswordEmail = function (userId, email) {
   // Make sure the user exists, and email is one of their addresses.
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
+
   if (!user)
     throw new Error("Can't find user");
   // pick the first email if we weren't passed an email.
@@ -540,9 +568,12 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
     email: email,
     when: when
   };
+  Meteor.users.setResetToken(userId, tokenRecord);
+  /*
   Meteor.users.update(userId, {$set: {
     "services.password.reset": tokenRecord
   }});
+  */
   // before passing to template, update user object with new token
   Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
 
@@ -585,12 +616,13 @@ Accounts.sendResetPasswordEmail = function (userId, email) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first email in the list.
+ * @importFromPackage accounts-base
  */
 Accounts.sendEnrollmentEmail = function (userId, email) {
   // XXX refactor! This is basically identical to sendResetPasswordEmail.
 
   // Make sure the user exists, and email is in their addresses.
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Error("Can't find user");
   // pick the first email if we weren't passed an email.
@@ -607,10 +639,12 @@ Accounts.sendEnrollmentEmail = function (userId, email) {
     email: email,
     when: when
   };
+  Meteor.users.setResetToken(userId, tokenRecord);
+  /*
   Meteor.users.update(userId, {$set: {
     "services.password.reset": tokenRecord
   }});
-
+   */
   // before passing to template, update user object with new token
   Meteor._ensure(user, 'services', 'password').reset = tokenRecord;
 
@@ -653,9 +687,11 @@ Meteor.methods({resetPassword: function (token, newPassword) {
     function () {
       check(token, String);
       check(newPassword, passwordValidator);
-
+      var user = Meteor.users.findByResetToken(token);
+      /*
       var user = Meteor.users.findOne({
         "services.password.reset.token": token});
+        */
       if (!user)
         throw new Meteor.Error(403, "Token expired");
       var email = user.services.password.reset.email;
@@ -682,6 +718,9 @@ Meteor.methods({resetPassword: function (token, newPassword) {
         // - Changing the password to the new one
         // - Forgetting about the reset token that was just used
         // - Verifying their email, since they got the password reset via email.
+
+        var affectedRecords = Meteor.users.changePasswordResetVerifyEmail(user._id, email, token, hashed);
+        /*
         var affectedRecords = Meteor.users.update(
           {
             _id: user._id,
@@ -692,6 +731,7 @@ Meteor.methods({resetPassword: function (token, newPassword) {
                   'emails.$.verified': true},
            $unset: {'services.password.reset': 1,
                     'services.password.srp': 1}});
+         */
         if (affectedRecords !== 1)
           return {
             userId: user._id,
@@ -724,6 +764,7 @@ Meteor.methods({resetPassword: function (token, newPassword) {
  * @locus Server
  * @param {String} userId The id of the user to send email to.
  * @param {String} [email] Optional. Which address of the user's to send the email to. This address must be in the user's `emails` list. Defaults to the first unverified email in the list.
+ * @importFromPackage accounts-base
  */
 Accounts.sendVerificationEmail = function (userId, address) {
   // XXX Also generate a link using which someone can delete this
@@ -731,7 +772,7 @@ Accounts.sendVerificationEmail = function (userId, address) {
   // this account.
 
   // Make sure the user exists, and address is one of their addresses.
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Error("Can't find user");
   // pick the first unverified address if we weren't passed an address.
@@ -753,9 +794,12 @@ Accounts.sendVerificationEmail = function (userId, address) {
     token: Random.secret(),
     address: address,
     when: new Date()};
+  Meteor.users.setVerificationTokens(userId, tokenRecord);
+  /*
   Meteor.users.update(
     {_id: userId},
     {$push: {'services.email.verificationTokens': tokenRecord}});
+    */
 
   // before passing to template, update user object with new token
   Meteor._ensure(user, 'services', 'email');
@@ -801,9 +845,11 @@ Meteor.methods({verifyEmail: function (token) {
     "password",
     function () {
       check(token, String);
-
+      var user = Meteor.users.findByVerificationTokens(token);
+      /*
       var user = Meteor.users.findOne(
         {'services.email.verificationTokens.token': token});
+        */
       if (!user)
         throw new Meteor.Error(403, "Verify email link expired");
 
@@ -831,12 +877,14 @@ Meteor.methods({verifyEmail: function (token) {
       // array. See
       // http://www.mongodb.org/display/DOCS/Updating/#Updating-The%24positionaloperator)
       // http://www.mongodb.org/display/DOCS/Updating#Updating-%24pull
+      Meteor.users.setEmailVerified(user._id, tokenRecord.address);
+      /*
       Meteor.users.update(
         {_id: user._id,
          'emails.address': tokenRecord.address},
         {$set: {'emails.$.verified': true},
          $pull: {'services.email.verificationTokens': {address: tokenRecord.address}}});
-
+      */
       return {userId: user._id};
     }
   );
@@ -852,6 +900,7 @@ Meteor.methods({verifyEmail: function (token) {
  * @param {String} newEmail A new email address for the user.
  * @param {Boolean} [verified] Optional - whether the new email address should
  * be marked as verified. Defaults to false.
+ * @importFromPackage accounts-base
  */
 Accounts.addEmail = function (userId, newEmail, verified) {
   check(userId, NonEmptyString);
@@ -862,7 +911,7 @@ Accounts.addEmail = function (userId, newEmail, verified) {
     verified = false;
   }
 
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Meteor.Error(403, "User not found");
 
@@ -879,6 +928,8 @@ Accounts.addEmail = function (userId, newEmail, verified) {
 
   var didUpdateOwnEmail = _.any(user.emails, function(email, index) {
     if (caseInsensitiveRegExp.test(email.address)) {
+      Meteor.users.setNewEmailVerified(user._id, email.address, newEmail, verified);
+      /*
       Meteor.users.update({
         _id: user._id,
         'emails.address': email.address
@@ -886,6 +937,7 @@ Accounts.addEmail = function (userId, newEmail, verified) {
         'emails.$.address': newEmail,
         'emails.$.verified': verified
       }});
+      */
       return true;
     }
 
@@ -905,7 +957,8 @@ Accounts.addEmail = function (userId, newEmail, verified) {
 
   // Perform a case insensitive check for duplicates before update
   checkForCaseInsensitiveDuplicates('emails.address', 'Email', newEmail, user._id);
-
+  Meteor.users.addEmailAddressVerified(user._id, newEmail, verified);
+  /*
   Meteor.users.update({
     _id: user._id
   }, {
@@ -916,15 +969,18 @@ Accounts.addEmail = function (userId, newEmail, verified) {
       }
     }
   });
-
+  */
   // Perform another check after update, in case a matching user has been
   // inserted in the meantime
   try {
     checkForCaseInsensitiveDuplicates('emails.address', 'Email', newEmail, user._id);
   } catch (ex) {
     // Undo update if the check fails
+    Meteor.users.undoEmailAddressUpdate(user._id, newEmail);
+    /*
     Meteor.users.update({_id: user._id},
       {$pull: {emails: {address: newEmail}}});
+      */
     throw ex;
   }
 }
@@ -935,17 +991,20 @@ Accounts.addEmail = function (userId, newEmail, verified) {
  * @locus Server
  * @param {String} userId The ID of the user to update.
  * @param {String} email The email address to remove.
+ * @importFromPackage accounts-base
  */
 Accounts.removeEmail = function (userId, email) {
   check(userId, NonEmptyString);
   check(email, NonEmptyString);
 
-  var user = Meteor.users.findOne(userId);
+  var user = Meteor.users.findById(userId);
   if (!user)
     throw new Meteor.Error(403, "User not found");
-
+  Meteor.users.undoEmailAddressUpdate(user._id, email);
+  /*
   Meteor.users.update({_id: user._id},
     {$pull: {emails: {address: email}}});
+    */
 }
 
 ///
@@ -1061,7 +1120,12 @@ Accounts.createUser = function (options, callback) {
 ///
 /// PASSWORD-SPECIFIC INDEXES ON USERS
 ///
+if (Meteor.isServer) {
+  Meteor.users.ensurePasswordIndex();
+}
+/*
 Meteor.users._ensureIndex('services.email.verificationTokens.token',
                           {unique: 1, sparse: 1});
 Meteor.users._ensureIndex('services.password.reset.token',
                           {unique: 1, sparse: 1});
+*/

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -5,7 +5,7 @@ if (Meteor.isServer) {
   
   Meteor.methods({
     getResetToken: function () {
-      var token = Meteor.users.findById(this.userId).services.password.reset;
+      var token = Meteor.dataProvider.findById(this.userId).services.password.reset;
       return token;
     },
     addSkipCaseInsensitiveChecksForTest: function (value) {
@@ -15,7 +15,7 @@ if (Meteor.isServer) {
       delete Accounts._skipCaseInsensitiveChecksForTest[value];
     },
     countUsersOnServer: function (query) {
-      return Meteor.users.findBySelector(query).count();
+      return Meteor.dataProvider.findBySelector(query).count();
     }
   });
 }
@@ -670,7 +670,7 @@ if (Meteor.isClient) (function () {
       // Can't update fields other than profile.
 
       if (Meteor.isServer) {   // via AccountsProvider
-        Meteor.users.updateDisallowedAndProfile(this.userId, true, 42,
+        Meteor.dataProvider.updateDisallowedAndProfile(this.userId, true, 42,
             expect(function (err) {
               test.isTrue(err);
               test.equal(err.error, 403);
@@ -692,7 +692,7 @@ if (Meteor.isClient) (function () {
     function(test, expect) {
       // Can't update another user.
       if (Meteor.isServer) {  // via AccountsProvider
-        Meteor.users.updateProfile(this.otherUserId, 42,
+        Meteor.dataProvider.updateProfile(this.otherUserId, 42,
             expect(function (err) {
               test.isTrue(err);
               test.equal(err.error, 403);
@@ -711,7 +711,7 @@ if (Meteor.isClient) (function () {
       // Can't update using a non-ID selector. (This one is thrown client-side.)
       test.throws(function () {
         if (Meteor.isServer) { // via AccountsProvider
-          Meteor.users.updateProfileByUsername(this.username, 42);
+          Meteor.dataProvider.updateProfileByUsername(this.username, 42);
         } else {  // via MiniMongo
           Meteor.users.update(
               {username: this.username}, {$set: {'profile.updated': 42}});
@@ -722,7 +722,7 @@ if (Meteor.isClient) (function () {
     function(test, expect) {
       // Can update own profile using ID.
       if (Meteor.isServer) {
-        Meteor.users.updateProfile(this.userId, 42,
+        Meteor.dataProvider.updateProfile(this.userId, 42,
             expect(function (err) {
               test.isFalse(err);
               test.equal(42, Meteor.user().profile.updated);
@@ -1229,10 +1229,26 @@ if (Meteor.isServer) (function () {
                                         testOnCreateUserHook: true});
 
       test.isTrue(userId);
-      var user = Meteor.users.findById(userId);
+      var user = Meteor.dataProvider.findById(userId);
       test.equal(user.profile.touchedByOnCreateUser, true);
     });
 
+  Tinytest.add(
+      'passwords - compatibility with mongo provider - createUser hooks',
+      function (test) {
+        var username = Random.id();
+        test.throws(function () {
+          // should fail the new user validators
+          Accounts.createUser({username: username, profile: {invalid: true}});
+        });
+
+        var userId = Accounts.createUser({username: username,
+          testOnCreateUserHook: true});
+
+        test.isTrue(userId);
+        var user = Meteor.users.findById(userId);
+        test.equal(user.profile.touchedByOnCreateUser, true);
+      });
 
   Tinytest.add(
     'passwords - setPassword',
@@ -1242,13 +1258,13 @@ if (Meteor.isServer) (function () {
 
       var userId = Accounts.createUser({username: username, email: email});
 
-      var user = Meteor.users.findById(userId);
+      var user = Meteor.dataProvider.findById(userId);
       // no services yet.
       test.equal(user.services.password, undefined);
 
       // set a new password.
       Accounts.setPassword(userId, 'new password');
-      user = Meteor.users.findById(userId);
+      user = Meteor.dataProvider.findById(userId);
       var oldSaltedHash = user.services.password.bcrypt;
       test.isTrue(oldSaltedHash);
 
@@ -1256,35 +1272,85 @@ if (Meteor.isServer) (function () {
       // token.
       Accounts.sendResetPasswordEmail(userId, email);
       Accounts._insertLoginToken(userId, Accounts._generateStampedLoginToken());
-      test.isTrue(Meteor.users.findById(userId).services.password.reset);
-      test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
+      test.isTrue(Meteor.dataProvider.findById(userId).services.password.reset);
+      test.isTrue(Meteor.dataProvider.findById(userId).services.resume.loginTokens);
 
       // reset with the same password, see we get a different salted hash
       Accounts.setPassword(userId, 'new password', {logout: false});
-      user = Meteor.users.findById(userId);
+      user = Meteor.dataProvider.findById(userId);
       var newSaltedHash = user.services.password.bcrypt;
       test.isTrue(newSaltedHash);
       test.notEqual(oldSaltedHash, newSaltedHash);
       // No more reset token.
-      test.isFalse(Meteor.users.findById(userId).services.password.reset);
+      test.isFalse(Meteor.dataProvider.findById(userId).services.password.reset);
       // But loginTokens are still here since we did logout: false.
-      test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
+      test.isTrue(Meteor.dataProvider.findById(userId).services.resume.loginTokens);
 
       // reset again, see that the login tokens are gone.
       Accounts.setPassword(userId, 'new password');
-      user = Meteor.users.findById(userId);
+      user = Meteor.dataProvider.findById(userId);
       var newerSaltedHash = user.services.password.bcrypt;
       test.isTrue(newerSaltedHash);
       test.notEqual(oldSaltedHash, newerSaltedHash);
       test.notEqual(newSaltedHash, newerSaltedHash);
       // No more tokens.
-      test.isFalse(Meteor.users.findById(userId).services.password.reset);
-      test.isFalse(Meteor.users.findById(userId).services.resume.loginTokens);
+      test.isFalse(Meteor.dataProvider.findById(userId).services.password.reset);
+      test.isFalse(Meteor.dataProvider.findById(userId).services.resume.loginTokens);
 
       // cleanup
-      Meteor.users.removeById(userId);
+      Meteor.dataProvider.removeById(userId);
     });
 
+  Tinytest.add(
+      'passwords - compatibility with mongo provider - setPassword',
+      function (test) {
+        var username = Random.id();
+        var email = username + '-intercept@example.com';
+
+        var userId = Accounts.createUser({username: username, email: email});
+
+        var user = Meteor.users.findById(userId);
+        // no services yet.
+        test.equal(user.services.password, undefined);
+
+        // set a new password.
+        Accounts.setPassword(userId, 'new password');
+        user = Meteor.users.findById(userId);
+        var oldSaltedHash = user.services.password.bcrypt;
+        test.isTrue(oldSaltedHash);
+
+        // Send a reset password email (setting a reset token) and insert a login
+        // token.
+        Accounts.sendResetPasswordEmail(userId, email);
+        Accounts._insertLoginToken(userId, Accounts._generateStampedLoginToken());
+        test.isTrue(Meteor.users.findById(userId).services.password.reset);
+        test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
+
+        // reset with the same password, see we get a different salted hash
+        Accounts.setPassword(userId, 'new password', {logout: false});
+        user = Meteor.users.findById(userId);
+        var newSaltedHash = user.services.password.bcrypt;
+        test.isTrue(newSaltedHash);
+        test.notEqual(oldSaltedHash, newSaltedHash);
+        // No more reset token.
+        test.isFalse(Meteor.users.findById(userId).services.password.reset);
+        // But loginTokens are still here since we did logout: false.
+        test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
+
+        // reset again, see that the login tokens are gone.
+        Accounts.setPassword(userId, 'new password');
+        user = Meteor.users.findById(userId);
+        var newerSaltedHash = user.services.password.bcrypt;
+        test.isTrue(newerSaltedHash);
+        test.notEqual(oldSaltedHash, newerSaltedHash);
+        test.notEqual(newSaltedHash, newerSaltedHash);
+        // No more tokens.
+        test.isFalse(Meteor.users.findById(userId).services.password.reset);
+        test.isFalse(Meteor.users.findById(userId).services.resume.loginTokens);
+
+        // cleanup
+        Meteor.users.removeById(userId);
+      });
 
   // This test properly belongs in accounts-base/accounts_tests.js, but
   // this is where the tests that actually log in are.
@@ -1358,7 +1424,7 @@ if (Meteor.isServer) (function () {
         password: "old-password"
       });
 
-      var user = Meteor.users.findById(userId);
+      var user = Meteor.dataProvider.findById(userId);
 
       Accounts.sendResetPasswordEmail(userId, email);
 
@@ -1372,7 +1438,7 @@ if (Meteor.isServer) (function () {
 
       var newEmail = Random.id() + '-new@example.com';
 
-      Meteor.users.updateEmail(userId, newEmail);
+      Meteor.dataProvider.updateEmail(userId, newEmail);
       // Meteor.users.update(userId, {$set: {"emails.0.address": newEmail}});
 
 
@@ -1384,6 +1450,46 @@ if (Meteor.isServer) (function () {
         Meteor.call("login", {user: {username: username}, password: "new-password"});
       }, /Incorrect password/);
     });
+
+  Tinytest.add(
+      'passwords - compatibility with mongo provider - reset password doesn\t work if email changed after email sent',
+      function (test) {
+        var username = Random.id();
+        var email = username + '-intercept@example.com';
+
+        var userId = Accounts.createUser({
+          username: username,
+          email: email,
+          password: "old-password"
+        });
+
+        var user = Meteor.users.findById(userId);
+
+        Accounts.sendResetPasswordEmail(userId, email);
+
+        var resetPasswordEmailOptions =
+            Meteor.call("getInterceptedEmails", email)[0];
+
+        var re = new RegExp(Meteor.absoluteUrl() + "#/reset-password/(\\S*)");
+        var match = resetPasswordEmailOptions.text.match(re);
+        test.isTrue(match);
+        var resetPasswordToken = match[1];
+
+        var newEmail = Random.id() + '-new@example.com';
+
+        Meteor.users.updateEmail(userId, newEmail);
+        // Meteor.users.update(userId, {$set: {"emails.0.address": newEmail}});
+
+
+
+        test.throws(function () {
+          Meteor.call("resetPassword", resetPasswordToken, "new-password");
+        }, /Token has invalid email address/);
+        test.throws(function () {
+          Meteor.call("login", {user: {username: username}, password: "new-password"});
+        }, /Incorrect password/);
+      });
+
 
   // We should be able to change the username
   Tinytest.add("passwords - change username", function (test) {

--- a/packages/accounts-password/password_tests.js
+++ b/packages/accounts-password/password_tests.js
@@ -5,7 +5,7 @@ if (Meteor.isServer) {
   
   Meteor.methods({
     getResetToken: function () {
-      var token = Meteor.users.findOne(this.userId).services.password.reset;
+      var token = Meteor.users.findById(this.userId).services.password.reset;
       return token;
     },
     addSkipCaseInsensitiveChecksForTest: function (value) {
@@ -15,7 +15,7 @@ if (Meteor.isServer) {
       delete Accounts._skipCaseInsensitiveChecksForTest[value];
     },
     countUsersOnServer: function (query) {
-      return Meteor.users.find(query).count();
+      return Meteor.users.findBySelector(query).count();
     }
   });
 }
@@ -636,6 +636,8 @@ if (Meteor.isClient) (function () {
     }
   ]);
 
+
+  // nature of following test requires explict awareness of client or server side calling
   testAsyncMulti("passwords - allow rules", [
     // create a second user to have an id for in a later test
     function (test, expect) {
@@ -666,40 +668,75 @@ if (Meteor.isClient) (function () {
       test.notEqual(this.userId, null);
       test.notEqual(this.userId, this.otherUserId);
       // Can't update fields other than profile.
-      Meteor.users.update(
-        this.userId, {$set: {disallowed: true, 'profile.updated': 42}},
-        expect(function (err) {
-          test.isTrue(err);
-          test.equal(err.error, 403);
-          test.isFalse(_.has(Meteor.user(), 'disallowed'));
-          test.isFalse(_.has(Meteor.user().profile, 'updated'));
-        }));
+
+      if (Meteor.isServer) {   // via AccountsProvider
+        Meteor.users.updateDisallowedAndProfile(this.userId, true, 42,
+            expect(function (err) {
+              test.isTrue(err);
+              test.equal(err.error, 403);
+              test.isFalse(_.has(Meteor.user(), 'disallowed'));
+              test.isFalse(_.has(Meteor.user().profile, 'updated'));
+            })
+        );
+      } else {  // via MiniMongo
+        Meteor.users.update(
+            this.userId, {$set: {disallowed: true, 'profile.updated': 42}},
+            expect(function (err) {
+              test.isTrue(err);
+              test.equal(err.error, 403);
+              test.isFalse(_.has(Meteor.user(), 'disallowed'));
+              test.isFalse(_.has(Meteor.user().profile, 'updated'));
+            }));
+      }
     },
     function(test, expect) {
       // Can't update another user.
-      Meteor.users.update(
-        this.otherUserId, {$set: {'profile.updated': 42}},
-        expect(function (err) {
-          test.isTrue(err);
-          test.equal(err.error, 403);
-        }));
+      if (Meteor.isServer) {  // via AccountsProvider
+        Meteor.users.updateProfile(this.otherUserId, 42,
+            expect(function (err) {
+              test.isTrue(err);
+              test.equal(err.error, 403);
+            })
+        );
+      } else {  // via MiniMongo
+        Meteor.users.update(
+            this.otherUserId, {$set: {'profile.updated': 42}},
+            expect(function (err) {
+              test.isTrue(err);
+              test.equal(err.error, 403);
+            }));
+      }
     },
     function(test, expect) {
       // Can't update using a non-ID selector. (This one is thrown client-side.)
       test.throws(function () {
-        Meteor.users.update(
-          {username: this.username}, {$set: {'profile.updated': 42}});
+        if (Meteor.isServer) { // via AccountsProvider
+          Meteor.users.updateProfileByUsername(this.username, 42);
+        } else {  // via MiniMongo
+          Meteor.users.update(
+              {username: this.username}, {$set: {'profile.updated': 42}});
+        }
       });
       test.isFalse(_.has(Meteor.user().profile, 'updated'));
     },
     function(test, expect) {
       // Can update own profile using ID.
-      Meteor.users.update(
-        this.userId, {$set: {'profile.updated': 42}},
-        expect(function (err) {
-          test.isFalse(err);
-          test.equal(42, Meteor.user().profile.updated);
-        }));
+      if (Meteor.isServer) {
+        Meteor.users.updateProfile(this.userId, 42,
+            expect(function (err) {
+              test.isFalse(err);
+              test.equal(42, Meteor.user().profile.updated);
+            })
+        );
+      } else {
+
+        Meteor.users.update(
+            this.userId, {$set: {'profile.updated': 42}},
+            expect(function (err) {
+              test.isFalse(err);
+              test.equal(42, Meteor.user().profile.updated);
+            }));
+      }
     },
     logoutStep
   ]);
@@ -1192,7 +1229,7 @@ if (Meteor.isServer) (function () {
                                         testOnCreateUserHook: true});
 
       test.isTrue(userId);
-      var user = Meteor.users.findOne(userId);
+      var user = Meteor.users.findById(userId);
       test.equal(user.profile.touchedByOnCreateUser, true);
     });
 
@@ -1205,13 +1242,13 @@ if (Meteor.isServer) (function () {
 
       var userId = Accounts.createUser({username: username, email: email});
 
-      var user = Meteor.users.findOne(userId);
+      var user = Meteor.users.findById(userId);
       // no services yet.
       test.equal(user.services.password, undefined);
 
       // set a new password.
       Accounts.setPassword(userId, 'new password');
-      user = Meteor.users.findOne(userId);
+      user = Meteor.users.findById(userId);
       var oldSaltedHash = user.services.password.bcrypt;
       test.isTrue(oldSaltedHash);
 
@@ -1219,33 +1256,33 @@ if (Meteor.isServer) (function () {
       // token.
       Accounts.sendResetPasswordEmail(userId, email);
       Accounts._insertLoginToken(userId, Accounts._generateStampedLoginToken());
-      test.isTrue(Meteor.users.findOne(userId).services.password.reset);
-      test.isTrue(Meteor.users.findOne(userId).services.resume.loginTokens);
+      test.isTrue(Meteor.users.findById(userId).services.password.reset);
+      test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
 
       // reset with the same password, see we get a different salted hash
       Accounts.setPassword(userId, 'new password', {logout: false});
-      user = Meteor.users.findOne(userId);
+      user = Meteor.users.findById(userId);
       var newSaltedHash = user.services.password.bcrypt;
       test.isTrue(newSaltedHash);
       test.notEqual(oldSaltedHash, newSaltedHash);
       // No more reset token.
-      test.isFalse(Meteor.users.findOne(userId).services.password.reset);
+      test.isFalse(Meteor.users.findById(userId).services.password.reset);
       // But loginTokens are still here since we did logout: false.
-      test.isTrue(Meteor.users.findOne(userId).services.resume.loginTokens);
+      test.isTrue(Meteor.users.findById(userId).services.resume.loginTokens);
 
       // reset again, see that the login tokens are gone.
       Accounts.setPassword(userId, 'new password');
-      user = Meteor.users.findOne(userId);
+      user = Meteor.users.findById(userId);
       var newerSaltedHash = user.services.password.bcrypt;
       test.isTrue(newerSaltedHash);
       test.notEqual(oldSaltedHash, newerSaltedHash);
       test.notEqual(newSaltedHash, newerSaltedHash);
       // No more tokens.
-      test.isFalse(Meteor.users.findOne(userId).services.password.reset);
-      test.isFalse(Meteor.users.findOne(userId).services.resume.loginTokens);
+      test.isFalse(Meteor.users.findById(userId).services.password.reset);
+      test.isFalse(Meteor.users.findById(userId).services.resume.loginTokens);
 
       // cleanup
-      Meteor.users.remove(userId);
+      Meteor.users.removeById(userId);
     });
 
 
@@ -1321,7 +1358,7 @@ if (Meteor.isServer) (function () {
         password: "old-password"
       });
 
-      var user = Meteor.users.findOne(userId);
+      var user = Meteor.users.findById(userId);
 
       Accounts.sendResetPasswordEmail(userId, email);
 
@@ -1334,7 +1371,11 @@ if (Meteor.isServer) (function () {
       var resetPasswordToken = match[1];
 
       var newEmail = Random.id() + '-new@example.com';
-      Meteor.users.update(userId, {$set: {"emails.0.address": newEmail}});
+
+      Meteor.users.updateEmail(userId, newEmail);
+      // Meteor.users.update(userId, {$set: {"emails.0.address": newEmail}});
+
+
 
       test.throws(function () {
         Meteor.call("resetPassword", resetPasswordToken, "new-password");

--- a/packages/accounts-password/password_tests_setup.js
+++ b/packages/accounts-password/password_tests_setup.js
@@ -110,15 +110,20 @@ Meteor.methods({
   clearUsernameAndProfile: function () {
     if (!this.userId)
       throw new Error("Not logged in!");
+
+    Meteor.users.unsetProfile(this.userId);
+    /*
     Meteor.users.update(this.userId,
                         {$unset: {profile: 1, username: 1}});
+                        */
   },
 
   expireTokens: function () {
     Accounts._expireTokens(new Date(), this.userId);
   },
   removeUser: function (username) {
-    Meteor.users.remove({ "username": username });
+    // Meteor.users.remove({ "username": username });
+    Meteor.users.removeByUsername(username);
   }
 });
 
@@ -128,8 +133,16 @@ Meteor.methods({
 Meteor.methods({
   testCreateSRPUser: function () {
     var username = Random.id();
-    Meteor.users.remove({username: username});
+
+    Meteor.users.removeByUsername(username);
+
+    // Meteor.users.remove({username: username});
     var userId = Accounts.createUser({username: username});
+    Meteor.users.setSRP(userId, "iPNrshUEcpOSO5fRDu7o4RRDc9OJBCGGljYpcXCuyg9",
+        "Dk3lFggdEtcHU3aKm6Odx7sdcaIrMskQxBbqtBtFzt6",
+        "2e8bce266b1357edf6952cc56d979db19f699ced97edfb2854b95972f820b0c7006c1a18e98aad40edf3fe111b87c52ef7dd06b320ce452d01376df2d560fdc4d8e74f7a97bca1f67b3cfaef34dee34dd6c76571c247d762624dc166dab5499da06bc9358528efa75bf74e2e7f5a80d09e60acf8856069ae5cfb080f2239ee76"
+    );
+    /*
     Meteor.users.update(
       userId,
       { '$set': { 'services.password.srp': {
@@ -138,11 +151,14 @@ Meteor.methods({
           "verifier" : "2e8bce266b1357edf6952cc56d979db19f699ced97edfb2854b95972f820b0c7006c1a18e98aad40edf3fe111b87c52ef7dd06b320ce452d01376df2d560fdc4d8e74f7a97bca1f67b3cfaef34dee34dd6c76571c247d762624dc166dab5499da06bc9358528efa75bf74e2e7f5a80d09e60acf8856069ae5cfb080f2239ee76"
       } } }
     );
+    */
     return username;
   },
 
   testSRPUpgrade: function (username) {
-    var user = Meteor.users.findOne({username: username});
+    var user = Meteor.users.findByUsername(username);
+
+   // var user = Meteor.users.findOne({username: username});
     if (user.services && user.services.password && user.services.password.srp)
       throw new Error("srp wasn't removed");
     if (!(user.services && user.services.password && user.services.password.bcrypt))
@@ -150,7 +166,8 @@ Meteor.methods({
   },
 
   testNoSRPUpgrade: function (username) {
-    var user = Meteor.users.findOne({username: username});
+    // var user = Meteor.users.findOne({username: username});
+    var user = Meteor.users.findByUsername(username);
     if (user.services && user.services.password && user.services.password.bcrypt)
       throw new Error("bcrypt was added");
     if (user.services && user.services.password && ! user.services.password.srp)


### PR DESCRIPTION
- [x]  differentiate between code running on the client and on the server
- [x] rename `ModelUser` to the more descriptive `AccountsProvider`
- [x] only use (subclasses of) `AccountsProvider` on the server
- [x] Remove DDP connection dependency from `AccountsCommon` 
- [ ] remove setting of `this.users` from  `AccountsProvider`  (in discussion)
- [x] Make `user()`  abstract and implement separately on the client and server.
- [x] Accept DDP connection on  `AccountsClient` 
- [x] Move  `_initConnection` to `AccountsClient`
- [x]  initialize `this.users` on the client. 
- [x]  Client-side test code continue to use the minimongo API to access the users collection; full mutation support
- [ ] Pass  `AccountsProvider` instance when creating `AccountServer` (figure out connection management - mongo vs other providers)
- [ ]  Publish current user to  `users` collection from server  (TBD)
- [ ]  Publish other users from server, design new API (TBD)
- [x]  Add `this.accountsProvider` on server
- [ ]  implement backwards compatible method for caller wanting `this.users` when `AccountsProvider` is mongodb  (in discussion)
- [x]  rename `findSingle` to `findById`
- [ ]  replace/rename `findCurrentUser` and `findSingleLoggedIn`, perhaps with expanded `findById` (opting for rename vs combine, in consideration of non-mongo providers)
- [x]  rename `insertHLoginToken` to `insertHashedLoginToken`
- [ ]  cleanup and/or remove `findUsersInServices` and `getMongoUsersForReactiveWork`
- [x]  pass all unit tests
