### PR TITLE
change double quotes to single quote

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -1423,7 +1423,7 @@ function setupUsersCollection(users) {
   users._ensureIndex('services.resume.haveLoginTokensToDelete',
                      { sparse: 1 });
   // For expiring login tokens
-  users._ensureIndex("services.resume.loginTokens.when", { sparse: 1 });
+  users._ensureIndex('services.resume.loginTokens.when', { sparse: 1 });
 }
 
 ///


### PR DESCRIPTION
Double quotes used in `ensureIndex` sometimes may cause problems in some MongoDB host such as Microsoft Azure.